### PR TITLE
Fixed Title alignment issue on SearchResults page

### DIFF
--- a/app/src/components/SearchResultsCell.vue
+++ b/app/src/components/SearchResultsCell.vue
@@ -108,6 +108,7 @@ export default {
 .title {
   font-size: 1.2em;
   color: white;
+  text-align: left;
 }
 
 .plot {


### PR DESCRIPTION
Fixed issue https://github.com/ShinValor/Binger/issues/107

<img width="1227" alt="Screen Shot 2020-08-06 at 2 03 06 AM" src="https://user-images.githubusercontent.com/32843930/89496785-04d85800-d789-11ea-8fe7-d72769b0c6c0.png">
